### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Install additional Cygwin packages
 
 – gcc-core
 
-– gcc-g++
-
 – make
 
 – gcc-fortran

--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ Install additional Cygwin packages
 
 – gcc-core
 
-– cygwin32-gcc-g++
-
-– cygwin32-gcc-core
+– gcc-g++
 
 – make
 


### PR DESCRIPTION
I don't think there's such a thing as cygwin32-gcc-g++ or cygwin32-gcc-core 
```
$ cygcheck -c | grep -i gcc
gcc-core             11.4.0-1           OK
gcc-fortran          11.4.0-1           OK
gcc-g++              11.4.0-1           OK
gcc-objc             11.4.0-1           OK
gcc-objc++           11.4.0-1           OK
libgcc1              11.3.0-1           OK
```